### PR TITLE
changing the notion of a term from years to months

### DIFF
--- a/src/main/java/co/da/jmtg/amort/FixedAmortizationCalculators.java
+++ b/src/main/java/co/da/jmtg/amort/FixedAmortizationCalculators.java
@@ -1,26 +1,25 @@
 package co.da.jmtg.amort;
 
-import java.util.Map;
-
-import org.joda.time.LocalDate;
-
 import co.da.jmtg.pmt.PmtCalculator;
 import co.da.jmtg.pmt.extra.ExtraPmt;
+import org.joda.time.LocalDate;
+
+import java.util.Map;
 
 /**
  * <p>
  * Contains static classes pertaining to instances of <tt>FixedAmortizationCalculator</tt>.
  * </p>
- * 
+ *
  * <p>
  * The getDefaultFixedAmortizationCalculator methods return an instance of DefaultFixedAmortizationCalculator. These
  * objects use instance control. This means there will never be two DefaultFixedAmortizationCalculator objects that are
  * equal. Therefore, to compare two of these objects, it is safe to always use == instead of equals().
  * </p>
- * 
+ *
  * @since 1.0
  * @author David Armstrong
- * 
+ *
  */
 public class FixedAmortizationCalculators {
 
@@ -29,18 +28,18 @@ public class FixedAmortizationCalculators {
 
     /**
      * Creates a DefaultFixedAmortizationCalculator with no extra payments
-     * 
+     *
      * @param pmtCalculator
      *            The mortgage data, including payment amounts, for the mortgage this FixedAmortizationCalculator will
      *            represent
      * @param pmtKey
      *            The mortgage start date, and interval between payments for this mortgage
-     * 
+     *
      * @return DefaultFixedAmortizationCalculator
-     * 
+     *
      * @throws NullPointerException
      *             if pmtCalculator or pmtKey is null.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if PmtPeriod in PmtCalculator is not BIWEEKLY, RAPID_BIWEEKLY, MONTHLY, WEEKLY, or RAPID_WEEKLY.
      */
@@ -51,7 +50,7 @@ public class FixedAmortizationCalculators {
 
     /**
      * Creates a DefaultFixedAmortizationCalculator with extra payments
-     * 
+     *
      * @param pmtCalculator
      *            The mortgage data, including payment amounts, for the mortgage this FixedAmortizationCalculator will
      *            represent
@@ -59,15 +58,15 @@ public class FixedAmortizationCalculators {
      *            The mortgage start date, and interval between payments for this mortgage
      * @param extraPmts
      *            extra payments for this mortgage, represented by an ExtraPmt object
-     * 
+     *
      * @return DefaultFixedAmortizationCalculator
-     * 
+     *
      * @throws NullPointerException
      *             if pmtCalculator, pmtKey, or extraPmts is null.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if PmtPeriod in PmtCalculator is not BIWEEKLY, RAPID_BIWEEKLY, MONTHLY, WEEKLY, or RAPID_WEEKLY.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if extraPmts contains dates that are not valid payment dates for the mortgage this object represents.
      */
@@ -78,7 +77,7 @@ public class FixedAmortizationCalculators {
 
     /**
      * Creates a DefaultFixedAmortizationCalculator with extra payments
-     * 
+     *
      * @param pmtCalculator
      *            The mortgage data, including payment amounts, for the mortgage this FixedAmortizationCalculator will
      *            represent
@@ -86,15 +85,15 @@ public class FixedAmortizationCalculators {
      *            The mortgage start date, and interval between payments for this mortgage
      * @param extraPmts
      *            extra payments for this mortgage, represented by an Iteration of ExtraPmt objects
-     * 
+     *
      * @return DefaultFixedAmortizationCalculator
-     * 
+     *
      * @throws NullPointerException
      *             if pmtCalculator, pmtKey, or extraPmts is null.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if PmtPeriod in PmtCalculator is not BIWEEKLY, RAPID_BIWEEKLY, MONTHLY, WEEKLY, or RAPID_WEEKLY.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if extraPmts contains dates that are not valid payment dates for the mortgage this object represents.
      */
@@ -105,22 +104,22 @@ public class FixedAmortizationCalculators {
 
     /**
      * Creates a DefaultFixedAmortizationCalculator with extra payments
-     * 
+     *
      * @param pmtCalculator
      *            The mortgage data, including payment amounts, for the mortgage this FixedAmortizationCalculator will
      *            represent
      * @param pmtKey
      *            The mortgage start date, and interval between payments for this mortgage
      * @param extraPmts
-     *            extra payments for this mortgage, represented by an Map<LocalDate, Double> object
+     *            extra payments for this mortgage, represented by an Map&lt;LocalDate, Double&gt; object
      * @return DefaultFixedAmortizationCalculator
-     * 
+     *
      * @throws NullPointerException
      *             if pmtCalculator, pmtKey, or extraPmts is null.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if PmtPeriod in PmtCalculator is not BIWEEKLY, RAPID_BIWEEKLY, MONTHLY, WEEKLY, or RAPID_WEEKLY.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if extraPmts contains dates that are not valid payment dates for the mortgage this object represents.
      */

--- a/src/main/java/co/da/jmtg/pmt/PmtCalculator.java
+++ b/src/main/java/co/da/jmtg/pmt/PmtCalculator.java
@@ -6,23 +6,23 @@ import co.da.jmtg.amort.FixedAmortizationCalculator;
  * A payment calculator for a fixed mortgage. An implementation of this interface calculates the interval payment of a
  * fixed mortgage given the interest rate, loan amount, and length of mortgage term in years. The interval between each
  * payment is defined by {@link PmtPeriod}.
- * 
+ *
  * @since 1.0
  * @author david
- * 
+ *
  */
 public interface PmtCalculator extends Comparable<PmtCalculator> {
 
     /**
      * Gets the loan amount used to determine the payment.
-     * 
+     *
      * @return loan amount as <tt>double</tt>.
      */
     double getLoanAmt();
 
     /**
      * Gets the interest rate used to determine the payment.
-     * 
+     *
      * @return interest rate as <tt>double</tt>.
      */
     double getInterestRate();
@@ -30,7 +30,7 @@ public interface PmtCalculator extends Comparable<PmtCalculator> {
     /**
      * Gets the interval interest rate used to determine the payment. This value is used by implementations of
      * {@link FixedAmortizationCalculator} when building an amortization table.
-     * 
+     *
      * @return interval interest rate as <tt>double</tt>.
      */
     double getPeriodInterestRate();
@@ -38,21 +38,21 @@ public interface PmtCalculator extends Comparable<PmtCalculator> {
     /**
      * Gets the payment count used to determine the payment. For a 30 year loan with a monthly payment interval, this
      * value would be 360.
-     * 
+     *
      * @return payment count as <tt>int</tt>.
      */
     int getPmtCt();
 
     /**
-     * Gets the duration of the mortgage term in years.
-     * 
-     * @return years as <tt>int</tt>.
+     * Gets the duration of the mortgage term.
+     *
+     * @return term as <tt>int</tt>.
      */
-    int getYears();
+    int getTerm();
 
     /**
      * Gets the interval used to determine the payment. The interval can be weekly, biweekly, or monthly.
-     * 
+     *
      * @return {@link PmtPeriod}
      */
     PmtPeriod getPmtPeriod();
@@ -60,7 +60,7 @@ public interface PmtCalculator extends Comparable<PmtCalculator> {
     /**
      * Sets the loan amount used to determine the payment. This method encourages implementations to be immutable by
      * specifying that it returns an object that implements <tt>PmtCalculator</tt>.
-     * 
+     *
      * @param loanAmt
      *            the loan amount as <tt>double</tt> to be used to calculate the payment.
      * @return new <tt>PmtCalculator</tt> instance
@@ -70,7 +70,7 @@ public interface PmtCalculator extends Comparable<PmtCalculator> {
     /**
      * Sets the interest rate used to determine the payment. This method encourages implementations to be immutable by
      * specifying that it returns an object that implements <tt>PmtCalculator</tt>.
-     * 
+     *
      * @param interestRate
      *            the interest rate as <tt>double</tt> to be used to calculate the payment.
      * @return new <tt>PmtCalculator</tt> instance
@@ -80,7 +80,7 @@ public interface PmtCalculator extends Comparable<PmtCalculator> {
     /**
      * Sets the years used to determine the payment. This method encourages implementations to be immutable by
      * specifying that it returns an object that implements <tt>PmtCalculator</tt>.
-     * 
+     *
      * @param years
      *            as <tt>int</tt> to be used to calculate the payment.
      * @return new <tt>PmtCalculator</tt> instance
@@ -90,7 +90,7 @@ public interface PmtCalculator extends Comparable<PmtCalculator> {
     /**
      * Sets the PmtPeriod used to determine the payment. This method encourages implementations to be immutable by
      * specifying that it returns an object that implements <tt>PmtCalculator</tt>.
-     * 
+     *
      * @param pmtPeriod
      *            {@link PmtPeriod} object to be used to calculate the payment.
      * @return new <tt>PmtCalculator</tt> instance
@@ -99,7 +99,7 @@ public interface PmtCalculator extends Comparable<PmtCalculator> {
 
     /**
      * Gets the payment. Implementations of this method should return the payment amount rounded.
-     * 
+     *
      * @return payment rounded as <tt>double</tt>.
      */
     double getPmt();
@@ -107,7 +107,7 @@ public interface PmtCalculator extends Comparable<PmtCalculator> {
     /**
      * Gets the unrounded payment. This method is used by implementations of <tt>FixedAmortizationBuilder</tt> when
      * building an amortization schedule.
-     * 
+     *
      * @return payment as <tt>double</tt>.
      */
     double getPmtUnrounded();

--- a/src/test/java/co/da/jmtg/amort/DefaultFixedAmortizationCalculatorTest.java
+++ b/src/test/java/co/da/jmtg/amort/DefaultFixedAmortizationCalculatorTest.java
@@ -1,31 +1,25 @@
 package co.da.jmtg.amort;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-
-import org.joda.time.LocalDate;
-import org.joda.time.Period;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import co.da.jmtg.amort.FixedAmortizationCalculator.Payment;
 import co.da.jmtg.pmt.PmtCalculator;
 import co.da.jmtg.pmt.PmtCalculators;
 import co.da.jmtg.pmt.PmtPeriod;
 import co.da.jmtg.pmt.extra.ExtraPmt;
 import co.da.jmtg.pmt.extra.ExtraPmts;
-
 import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Ordering;
+import org.joda.time.LocalDate;
+import org.joda.time.Period;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertTrue;
 
 public class DefaultFixedAmortizationCalculatorTest {
 
@@ -491,9 +485,9 @@ public class DefaultFixedAmortizationCalculatorTest {
         PmtPeriod pmtPeriod = PmtPeriod.MONTHLY;
         double loanAmt = 150000.00;
         double interestRate = 4.25;
-        int years = 20;
-        PmtCalculator pmtCalculator = PmtCalculators.getDefaultPmtCalculator(pmtPeriod, loanAmt, interestRate, years);
-        PmtKey pmtKey = PmtKeys.getDefaultPmtKeyForYears(pmtPeriod, years);
+        int term = 240;
+        PmtCalculator pmtCalculator = PmtCalculators.getDefaultPmtCalculator(pmtPeriod, loanAmt, interestRate, term);
+        PmtKey pmtKey = PmtKeys.getDefaultPmtKeyForYears(pmtPeriod, term);
 
         FixedAmortizationCalculator amortCalculator = FixedAmortizationCalculators
                 .getDefaultFixedAmortizationCalculator(
@@ -521,9 +515,9 @@ public class DefaultFixedAmortizationCalculatorTest {
         PmtPeriod pmtPeriod = PmtPeriod.MONTHLY;
         double loanAmt = 150000.00;
         double interestRate = 4.25;
-        int years = 20;
-        PmtCalculator pmtCalculator = PmtCalculators.getDefaultPmtCalculator(pmtPeriod, loanAmt, interestRate, years);
-        PmtKey pmtKey = PmtKeys.getDefaultPmtKeyForYears(pmtPeriod, years);
+        int term = 240;
+        PmtCalculator pmtCalculator = PmtCalculators.getDefaultPmtCalculator(pmtPeriod, loanAmt, interestRate, term);
+        PmtKey pmtKey = PmtKeys.getDefaultPmtKeyForYears(pmtPeriod, term);
 
         // Create the calculator with extra payments.
         FixedAmortizationCalculator amortCalculator = FixedAmortizationCalculators

--- a/src/test/java/co/da/jmtg/pmt/CanadianPmtCalculatorTest.java
+++ b/src/test/java/co/da/jmtg/pmt/CanadianPmtCalculatorTest.java
@@ -1,11 +1,9 @@
 package co.da.jmtg.pmt;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 
 public class CanadianPmtCalculatorTest {
 
@@ -15,20 +13,20 @@ public class CanadianPmtCalculatorTest {
 
         // The monthly payment for this loan should be $1013.37.
         double expected = 1008.43;
-        PmtCalculator pmtCalc = PmtCalculators.getCanadianPmtCalculator(PmtPeriod.MONTHLY, 200000, 4.5, 30);
+        PmtCalculator pmtCalc = PmtCalculators.getCanadianPmtCalculator(PmtPeriod.MONTHLY, 200000, 4.5, 360);
         double pmt = pmtCalc.getPmt();
         assertThat(pmt, is(expected));
 
         // The rapid biweekly payment for this loan should be $513.29.
         expected = 513.29;
-        pmtCalc = PmtCalculators.getCanadianPmtCalculator(PmtPeriod.RAPID_BIWEEKLY, 150000, 5.5, 20);
+        pmtCalc = PmtCalculators.getCanadianPmtCalculator(PmtPeriod.RAPID_BIWEEKLY, 150000, 5.5, 240);
         pmt = pmtCalc.getPmt();
         assertThat(pmt, is(expected));
 
         // This one matches up with the rate here: https://www.rbcroyalbank.com/cgi-bin/mortgage/mpc/start.cgi/start
         // The biweekly payment for this loan should be $473.81.
         expected = 473.81;
-        pmtCalc = PmtCalculators.getCanadianPmtCalculator(PmtPeriod.BIWEEKLY, 150000, 5.5, 20);
+        pmtCalc = PmtCalculators.getCanadianPmtCalculator(PmtPeriod.BIWEEKLY, 150000, 5.5, 240);
         pmt = pmtCalc.getPmt();
         assertThat(pmt, is(expected));
     }

--- a/src/test/java/co/da/jmtg/pmt/DefaultPmtCalculatorTest.java
+++ b/src/test/java/co/da/jmtg/pmt/DefaultPmtCalculatorTest.java
@@ -1,11 +1,9 @@
 package co.da.jmtg.pmt;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 
 public class DefaultPmtCalculatorTest {
 
@@ -15,19 +13,19 @@ public class DefaultPmtCalculatorTest {
 
         // The monthly payment for this loan should be $1013.37.
         double expected = 1013.37;
-        PmtCalculator pmtCalculator = PmtCalculators.getDefaultPmtCalculator(PmtPeriod.MONTHLY, 200000.00, 4.5, 30);
+        PmtCalculator pmtCalculator = PmtCalculators.getDefaultPmtCalculator(PmtPeriod.MONTHLY, 200000.00, 4.5, 360);
         double pmt = pmtCalculator.getPmt();
         assertThat(pmt, is(expected));
 
         // The monthly payment for this loan should be $1097.75.
         expected = 1097.75;
-        pmtCalculator = PmtCalculators.getDefaultPmtCalculator(PmtPeriod.MONTHLY, 165000.00, 7.0, 30);
+        pmtCalculator = PmtCalculators.getDefaultPmtCalculator(PmtPeriod.MONTHLY, 165000.00, 7.0, 360);
         pmt = pmtCalculator.getPmt();
         assertThat(pmt, is(expected));
 
         // The monthly payment for this loan should be $1271.79.
         expected = 1271.79;
-        pmtCalculator = PmtCalculators.getDefaultPmtCalculator(PmtPeriod.MONTHLY, 183000, 5.625, 20);
+        pmtCalculator = PmtCalculators.getDefaultPmtCalculator(PmtPeriod.MONTHLY, 183000, 5.625, 240);
         pmt = pmtCalculator.getPmt();
         assertThat(pmt, is(expected));
     }


### PR DESCRIPTION
@darmstrong1 I think it is more useful to store the notion of term in months.

It is how most US loans are reported, could be different other countries. 

My specific need revolves around loans which don't fit neatly into a year `int`. 

Please have a look. I fixed the tests which broke as a result of my change.